### PR TITLE
Add tests for connect logic

### DIFF
--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -1,0 +1,81 @@
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
+import flask
+import pytest
+
+from flask_arango_orm import ArangoORM
+
+
+@pytest.fixture
+def app():
+    app = flask.Flask(__name__)
+    app.config.update(
+        ARANGODB_DATABASE='db',
+        ARANGODB_USER='user',
+        ARANGODB_PASSWORD='pass',
+        ARANGODB_HOST=('http', 'localhost', 8529),
+        ARANGODB_CLUSTER=False,
+    )
+    return app
+
+
+@mock.patch('flask_arango_orm.arango.Database')
+@mock.patch('flask_arango_orm.arango.ArangoClient')
+def test_connect_single_host(mock_client_cls, mock_database_cls, app):
+    arango = ArangoORM(app)
+
+    mock_client = mock.Mock()
+    mock_client.db.return_value = 'db_obj'
+    mock_client_cls.return_value = mock_client
+    mock_db = mock_database_cls.return_value
+
+    with app.app_context():
+        conn = arango.connect()
+
+    assert conn is mock_db
+    mock_client_cls.assert_called_once_with(hosts='http://localhost:8529')
+    mock_client.db.assert_called_once_with(
+        name='db', username='user', password='pass'
+    )
+    mock_database_cls.assert_called_once_with('db_obj')
+
+
+@mock.patch('flask_arango_orm.arango.ConnectionPool')
+@mock.patch('flask_arango_orm.arango.ArangoClient')
+def test_connect_cluster(mock_client_cls, mock_pool_cls, app):
+    app.config['ARANGODB_CLUSTER'] = True
+    app.config['ARANGODB_HOST_POOL'] = [
+        ('http', 'host1', 8529),
+        ('http', 'host2', 8529),
+    ]
+    arango = ArangoORM(app)
+
+    client1 = mock.Mock(name='client1')
+    client2 = mock.Mock(name='client2')
+    mock_client_cls.side_effect = [client1, client2]
+    pool = mock_pool_cls.return_value
+
+    with app.app_context():
+        conn = arango.connect()
+
+    assert conn is pool
+    mock_client_cls.assert_has_calls([
+        mock.call(hosts='http://host1:8529'),
+        mock.call(hosts='http://host2:8529'),
+    ])
+    mock_pool_cls.assert_called_once_with(
+        [client1, client2], dbname='db', username='user', password='pass'
+    )
+
+
+def test_teardown_closes_connection(app):
+    arango = ArangoORM(app)
+    dummy_conn = mock.Mock()
+    with app.app_context():
+        flask.current_app.extensions['arango'] = dummy_conn
+        arango.teardown()
+        assert flask.current_app.extensions.get('arango') is None
+    dummy_conn.close.assert_called_once()


### PR DESCRIPTION
## Summary
- add fixture-based tests for connecting to single-host and cluster setups
- verify teardown closes the db connection

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68492513fedc83338c3181d36058811f