### PR TITLE
Update README and docs for modern usage

### DIFF
--- a/docs/clusters.rst
+++ b/docs/clusters.rst
@@ -1,0 +1,29 @@
+Cluster Connections
+===================
+
+Flask-arango-orm can connect to an ArangoDB cluster using
+`python-arango`_. Enable ``ARANGODB_CLUSTER`` and provide
+``ARANGODB_HOST_POOL`` with the coordinator hosts.
+
+.. code-block:: python
+
+   from flask import Flask
+   from flask_arango_orm import ArangoORM
+
+   def create_app() -> Flask:
+       app = Flask(__name__)
+
+       pool = [
+           ('http', 'coordinator1', 8529),
+           ('http', 'coordinator2', 8529),
+       ]
+       app.config.update(
+           ARANGODB_CLUSTER=True,
+           ARANGODB_HOST_POOL=pool,
+       )
+
+       ArangoORM(app)
+       return app
+
+For more details on cluster connection handling see the
+`python-arango documentation <https://python-arango.readthedocs.io/>`_.

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -3,6 +3,10 @@ Configuration Options
 
 All configuration options are to be specified in the Flask app's config
 
+They can also be loaded from environment variables when initializing the
+application. The :ref:`create_app` example in the README demonstrates
+using ``os.getenv`` to configure the extension.
+
 
 .. py:attribute:: ARANGODB_DATABASE
    str

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,6 +11,7 @@ Welcome to Flask-arango-orm's documentation!
    :caption: Contents:
 
    configuration
+   clusters
    api
 
 


### PR DESCRIPTION
## Summary
- document installation with Poetry and pip
- show `create_app` pattern with env vars
- add guide for cluster connections
- link cluster guide in docs

## Testing
- `pip install -e . -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849251113b083339cbaebc13a4f8df4