### PR TITLE
Remove mock dev dependency

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -468,23 +468,6 @@ files = [
 ]
 
 [[package]]
-name = "mock"
-version = "5.2.0"
-description = "Rolling backport of unittest.mock for all Pythons"
-optional = false
-python-versions = ">=3.6"
-groups = ["dev"]
-files = [
-    {file = "mock-5.2.0-py3-none-any.whl", hash = "sha256:7ba87f72ca0e915175596069dbbcc7c75af7b5e9b9bc107ad6349ede0819982f"},
-    {file = "mock-5.2.0.tar.gz", hash = "sha256:4e460e818629b4b173f32d08bf30d3af8123afbb8e04bb5707a1fd4799e503f0"},
-]
-
-[package.extras]
-build = ["blurb", "twine", "wheel"]
-docs = ["sphinx"]
-test = ["pytest", "pytest-cov"]
-
-[[package]]
 name = "packaging"
 version = "25.0"
 description = "Core utilities for Python packages"
@@ -948,4 +931,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<4.0"
-content-hash = "92936861ee7cd4cf24ce93171cd1bfcf1b2f6dc45551ae2829a4c8672d3938a3"
+content-hash = "e87ff698bbbd1e81f22fd6c6727ac433e54c7b59f0341707d6c11bb72cd4f8d3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,6 @@ flask = ">=2.0.0"
 pytest = ">=4.3.0"
 pytest-cov = "^4.1.0"
 pytest-flake8 = "^1.1.1"
-mock = "^5.1.0"
 six = "^1.16.0"
 
 [build-system]

--- a/tests/test_arango.py
+++ b/tests/test_arango.py
@@ -1,7 +1,4 @@
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+from unittest import mock
 
 from flask_arango_orm import ArangoORM
 from flask_arango_orm.arango import ARANGODB_CLUSTER, ARANGODB_HOST

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -1,7 +1,4 @@
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+from unittest import mock
 
 import flask
 import pytest


### PR DESCRIPTION
## Summary
- drop the `mock` package from dev deps
- update tests to import `mock` from `unittest`
- regenerate the lock file

## Testing
- `poetry install -n`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684929d0d3e8833398392b9202b86328