### PR TITLE
Return database object from connect()

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -64,10 +64,11 @@ The extension integrates `arango-orm` with your Flask application. A modern
 
        arango = ArangoORM(app)
 
-       @app.route('/route')
-       def some_route():
-           db_conn = arango.connection
-           return 'ok'
+      @app.route('/route')
+      def some_route():
+          # ``db_conn`` is an ``arango_orm.database.Database`` instance
+          db_conn = arango.connection
+          return 'ok'
 
        return app
 
@@ -76,7 +77,9 @@ Connecting to ArangoDB clusters
 
 To work with an ArangoDB cluster enable ``ARANGODB_CLUSTER`` and provide
 ``ARANGODB_HOST_POOL`` with the coordinator URLs. The extension uses
-``python-arango``'s ``ArangoClient`` to create a connection pool.
+``python-arango``'s ``ArangoClient`` to create a connection pool.  The
+``connection`` property returns the next ``Database`` instance from this
+pool.
 
 .. code-block:: python
 

--- a/flask_arango_orm/arango.py
+++ b/flask_arango_orm/arango.py
@@ -63,8 +63,8 @@ class ArangoORM:
         If ARANGODB_CLUSTER is True, then the host configuration is
         taken from ARANGODB_HOST_POOL, otherwise ARANGODB_HOST is used.
 
-        :returns: Connection pool for ArangoDB
-        :rtype: arango_orm.connection_pool.ConnectionPool
+        :returns: Database connection
+        :rtype: arango_orm.database.Database
         """
         db_name = current_app.config['ARANGODB_DATABASE']
         username = current_app.config['ARANGODB_USER']
@@ -87,12 +87,13 @@ class ArangoORM:
                 )
             )
 
-        return ConnectionPool(
+        pool = ConnectionPool(
             hosts,
             dbname=db_name,
             password=password,
             username=username,
         )
+        return pool._db
 
     @property
     def connection(self):
@@ -103,8 +104,8 @@ class ArangoORM:
         connection does not currently exist, :py:func:`connect` is
         called.
 
-        :returns: Connection pool instance
-        :rtype: arango_orm.connection_pool.ConnectionPool
+        :returns: Database instance
+        :rtype: arango_orm.database.Database
         """
         if current_app.extensions.get('arango') is None:
             current_app.extensions['arango'] = self.connect()

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -27,11 +27,13 @@ def test_connect_single_host(mock_client_cls, mock_pool_cls, app):
     mock_client = mock.Mock()
     mock_client_cls.return_value = mock_client
     pool = mock_pool_cls.return_value
+    db_obj = mock.Mock(name='db')
+    pool._db = db_obj
 
     with app.app_context():
         conn = arango.connect()
 
-    assert conn is pool
+    assert conn is db_obj
     mock_client_cls.assert_called_once_with(hosts='http://localhost:8529')
     mock_pool_cls.assert_called_once_with(
         [mock_client], dbname='db', username='user', password='pass'
@@ -52,11 +54,13 @@ def test_connect_cluster(mock_client_cls, mock_pool_cls, app):
     client2 = mock.Mock(name='client2')
     mock_client_cls.side_effect = [client1, client2]
     pool = mock_pool_cls.return_value
+    db_obj = mock.Mock(name='db')
+    pool._db = db_obj
 
     with app.app_context():
         conn = arango.connect()
 
-    assert conn is pool
+    assert conn is db_obj
     mock_client_cls.assert_has_calls([
         mock.call(hosts='http://host1:8529'),
         mock.call(hosts='http://host2:8529'),


### PR DESCRIPTION
## Summary
- return the `Database` instance from `connect()`
- store that object on `current_app.extensions['arango']`
- update usage notes in the README
- adjust unit tests for the new behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849b161100483339a03db724e4e9e65