### PR TITLE
Add AsyncArangoORM with aioarango

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -100,3 +100,22 @@ pool.
        ArangoORM(app)
        return app
 
+Async usage
+-----------
+
+``AsyncArangoORM`` works the same way when writing async routes. Retrieve the
+connection with ``await``:
+
+.. code-block:: python
+
+   from flask import Flask
+   from flask_arango_orm import AsyncArangoORM
+
+   app = Flask(__name__)
+   arango = AsyncArangoORM(app)
+
+   @app.get("/async")
+   async def async_route():
+       db = await arango.connection()
+       return "ok"
+

--- a/flask_arango_orm/__init__.py
+++ b/flask_arango_orm/__init__.py
@@ -1,6 +1,6 @@
 from importlib.metadata import PackageNotFoundError, version
 
-from .arango import ArangoORM
+from .arango import ArangoORM, AsyncArangoORM
 from .config import ArangoSettings
 
 try:
@@ -10,6 +10,7 @@ except PackageNotFoundError:  # pragma: no cover - package not installed
 
 __all__ = (
     "ArangoORM",
+    "AsyncArangoORM",
     "ArangoSettings",
     "__version__",
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,12 +28,14 @@ classifiers = [
 python = ">=3.11,<4.0"
 arango-orm = {version = "^1.1.0", python = ">=3.11"}
 python-arango = "^7.9.1"
+aioarango = "^1.0.0"
 flask = ">=2.0.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = ">=4.3.0"
 pytest-cov = "^4.1.0"
 pytest-flake8 = "^1.1.1"
+pytest-asyncio = "^1.0.0"
 six = "^1.16.0"
 black = "^23.3.0"
 ruff = "^0.4.4"

--- a/tests/test_async_arango.py
+++ b/tests/test_async_arango.py
@@ -1,0 +1,41 @@
+from unittest import mock
+
+import flask
+import pytest
+
+from flask_arango_orm import AsyncArangoORM
+from flask_arango_orm.arango import ARANGODB_CLUSTER, ARANGODB_HOST
+
+
+class TestAsyncArangoORM:
+    @mock.patch("flask.Flask")
+    def test_init(self, mock_flask):
+        app = mock_flask(__name__)
+        _ = AsyncArangoORM(app)
+        calls = [
+            mock.call("ARANGODB_CLUSTER", ARANGODB_CLUSTER),
+            mock.call("ARANGODB_HOST", ARANGODB_HOST),
+        ]
+        app.config.setdefault.assert_has_calls(calls)
+
+    def test_init_no_app(self):
+        arango = AsyncArangoORM()
+        assert arango.app is None
+
+    @pytest.mark.asyncio
+    @mock.patch.object(AsyncArangoORM, "connect", new_callable=mock.AsyncMock)
+    async def test_connection_attribute(self, mock_connect):
+        test_conn = object()
+        mock_client = mock.AsyncMock()
+        mock_connect.return_value = (mock_client, test_conn)
+
+        app = flask.Flask(__name__)
+        arango = AsyncArangoORM(app)
+        ctx = app.app_context()
+        ctx.push()
+        app.do_teardown_appcontext = lambda exc=None: None
+        db_conn = await arango.connection()
+        assert db_conn is test_conn
+        assert app.extensions["arango_async"] == (mock_client, test_conn)
+        await arango.teardown()
+        mock_connect.assert_awaited_once()

--- a/tests/test_async_connect.py
+++ b/tests/test_async_connect.py
@@ -1,0 +1,81 @@
+from unittest import mock
+
+import flask
+import pytest
+
+from flask_arango_orm import AsyncArangoORM
+
+
+@pytest.fixture
+def app():
+    app = flask.Flask(__name__)
+    app.config.update(
+        ARANGODB_DATABASE="db",
+        ARANGODB_USER="user",
+        ARANGODB_PASSWORD="pass",
+        ARANGODB_HOST=("http", "localhost", 8529),
+        ARANGODB_CLUSTER=False,
+    )
+    return app
+
+
+@pytest.mark.asyncio
+@mock.patch("flask_arango_orm.arango.AsyncArangoClient")
+async def test_connect_single_host(mock_client_cls, app):
+    arango = AsyncArangoORM(app)
+
+    mock_client = mock.AsyncMock()
+    mock_db = mock.AsyncMock()
+    mock_client.db.return_value = mock_db
+    mock_client_cls.return_value = mock_client
+
+    ctx = app.app_context()
+    ctx.push()
+    app.do_teardown_appcontext = lambda exc=None: None
+    client, db = await arango.connect()
+    await arango.teardown()
+
+    assert db is mock_db
+    mock_client_cls.assert_called_once_with(hosts=["http://localhost:8529"])
+    mock_client.db.assert_awaited_once_with("db", "user", "pass")
+
+
+@pytest.mark.asyncio
+@mock.patch("flask_arango_orm.arango.AsyncArangoClient")
+async def test_connect_cluster(mock_client_cls, app):
+    app.config["ARANGODB_CLUSTER"] = True
+    app.config["ARANGODB_HOST_POOL"] = [
+        ("http", "host1", 8529),
+        ("http", "host2", 8529),
+    ]
+    arango = AsyncArangoORM(app)
+
+    mock_client = mock.AsyncMock()
+    mock_db = mock.AsyncMock()
+    mock_client.db.return_value = mock_db
+    mock_client_cls.return_value = mock_client
+
+    ctx = app.app_context()
+    ctx.push()
+    app.do_teardown_appcontext = lambda exc=None: None
+    client, db = await arango.connect()
+    await arango.teardown()
+
+    assert db is mock_db
+    mock_client_cls.assert_called_once_with(
+        hosts=["http://host1:8529", "http://host2:8529"]
+    )
+    mock_client.db.assert_awaited_once_with("db", "user", "pass")
+
+
+@pytest.mark.asyncio
+async def test_teardown_closes_connection(app):
+    arango = AsyncArangoORM(app)
+    dummy_client = mock.AsyncMock()
+    dummy_db = mock.Mock()
+    ctx = app.app_context()
+    ctx.push()
+    flask.current_app.extensions["arango_async"] = (dummy_client, dummy_db)
+    await arango.teardown()
+    assert flask.current_app.extensions.get("arango_async") is None
+    dummy_client.close.assert_awaited_once()


### PR DESCRIPTION
## Summary
- implement AsyncArangoORM using aioarango
- expose AsyncArangoORM from package
- document async usage in README
- add aioarango dependency
- add pytest-asyncio to dev requirements
- test AsyncArangoORM with pytest.mark.asyncio

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849baf43dc48333a85346b279ad514b