### PR TITLE
Add Python 3.12 CI job and formatter config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,9 +31,37 @@ jobs:
           path: test-reports
       - store_artifacts:
           path: test-reports
+  unittest_py312:
+    docker:
+      - image: cimg/python:3.12
+    environment:
+      PYTEST_ADDOPTS: --cov-report=xml:test-reports/coverage.xml --junitxml=test-reports/junit.xml
+    steps:
+      - checkout
+      - restore_cache:
+          key: v1-dependency-cache-{{ .Branch }}-{{ checksum "poetry.lock" }}-py312
+      - python/install-packages:
+          pkg-manager: poetry
+      - run:
+          name: Fix arango-orm dependencies
+          command: |
+            poetry run pip install six
+      - run:
+          name: Run tests
+          command: |
+            poetry run pytest -vv --cov=flask_arango_orm tests/
+      - save_cache:
+          key: v1-dependency-cache-{{ .Branch }}-{{ checksum "poetry.lock" }}-py312
+          paths:
+            - "~/.cache/pypoetry"
+      - store_test_results:
+          path: test-reports
+      - store_artifacts:
+          path: test-reports
 
 workflows:
   version: 2
-  build_test_publish_py311:
+  build_test_publish:
     jobs:
       - unittest_py311
+      - unittest_py312

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,10 +3,12 @@ repos:
     rev: 23.3.0
     hooks:
       - id: black
+        args: [--config=pyproject.toml]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.4.4
     hooks:
       - id: ruff
+        args: [--config=pyproject.toml]
   - repo: local
     hooks:
       - id: pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,15 @@ black = "^23.3.0"
 ruff = "^0.4.4"
 pre-commit = "^3.7.0"
 
+[tool.black]
+line-length = 88
+target-version = ["py311"]
+
+[tool.ruff]
+line-length = 88
+target-version = "py311"
+src = ["flask_arango_orm", "tests"]
+
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
## Summary
- run tests on Python 3.12 in CircleCI
- configure formatting options for Black and Ruff
- reference pyproject in pre-commit hooks

## Testing
- `poetry run pre-commit run --files .circleci/config.yml pyproject.toml .pre-commit-config.yaml` *(fails: ImportError from requests_toolbelt)*

------
https://chatgpt.com/codex/tasks/task_e_6849c9e93b68833388fc9c6e977e4e3e