### PR TITLE
Add logging and config validation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -119,3 +119,15 @@ connection with ``await``:
        db = await arango.connection()
        return "ok"
 
+Logging
+-------
+
+``flask_arango_orm`` uses the standard :mod:`logging` package. The
+``flask_arango_orm.arango`` module exposes a logger named after the module,
+which reports connection attempts, successful connections and when connections
+are torn down.  Enable it with::
+
+   import logging
+   logging.basicConfig(level=logging.INFO)
+
+

--- a/tests/test_async_connect.py
+++ b/tests/test_async_connect.py
@@ -79,3 +79,15 @@ async def test_teardown_closes_connection(app):
     await arango.teardown()
     assert flask.current_app.extensions.get("arango_async") is None
     dummy_client.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_missing_config_raises(app):
+    app.config.pop("ARANGODB_DATABASE")
+    arango = AsyncArangoORM(app)
+    ctx = app.app_context()
+    ctx.push()
+    app.do_teardown_appcontext = lambda exc=None: None
+    with pytest.raises(ValueError) as exc:
+        await arango.connect()
+    assert "ARANGODB_DATABASE" in str(exc.value)

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -10,63 +10,65 @@ from flask_arango_orm import ArangoORM
 def app():
     app = flask.Flask(__name__)
     app.config.update(
-        ARANGODB_DATABASE='db',
-        ARANGODB_USER='user',
-        ARANGODB_PASSWORD='pass',
-        ARANGODB_HOST=('http', 'localhost', 8529),
+        ARANGODB_DATABASE="db",
+        ARANGODB_USER="user",
+        ARANGODB_PASSWORD="pass",
+        ARANGODB_HOST=("http", "localhost", 8529),
         ARANGODB_CLUSTER=False,
     )
     return app
 
 
-@mock.patch('flask_arango_orm.arango.ConnectionPool')
-@mock.patch('flask_arango_orm.arango.ArangoClient')
+@mock.patch("flask_arango_orm.arango.ConnectionPool")
+@mock.patch("flask_arango_orm.arango.ArangoClient")
 def test_connect_single_host(mock_client_cls, mock_pool_cls, app):
     arango = ArangoORM(app)
 
     mock_client = mock.Mock()
     mock_client_cls.return_value = mock_client
     pool = mock_pool_cls.return_value
-    db_obj = mock.Mock(name='db')
+    db_obj = mock.Mock(name="db")
     pool._db = db_obj
 
     with app.app_context():
         conn = arango.connect()
 
     assert conn is db_obj
-    mock_client_cls.assert_called_once_with(hosts='http://localhost:8529')
+    mock_client_cls.assert_called_once_with(hosts="http://localhost:8529")
     mock_pool_cls.assert_called_once_with(
-        [mock_client], dbname='db', username='user', password='pass'
+        [mock_client], dbname="db", username="user", password="pass"
     )
 
 
-@mock.patch('flask_arango_orm.arango.ConnectionPool')
-@mock.patch('flask_arango_orm.arango.ArangoClient')
+@mock.patch("flask_arango_orm.arango.ConnectionPool")
+@mock.patch("flask_arango_orm.arango.ArangoClient")
 def test_connect_cluster(mock_client_cls, mock_pool_cls, app):
-    app.config['ARANGODB_CLUSTER'] = True
-    app.config['ARANGODB_HOST_POOL'] = [
-        ('http', 'host1', 8529),
-        ('http', 'host2', 8529),
+    app.config["ARANGODB_CLUSTER"] = True
+    app.config["ARANGODB_HOST_POOL"] = [
+        ("http", "host1", 8529),
+        ("http", "host2", 8529),
     ]
     arango = ArangoORM(app)
 
-    client1 = mock.Mock(name='client1')
-    client2 = mock.Mock(name='client2')
+    client1 = mock.Mock(name="client1")
+    client2 = mock.Mock(name="client2")
     mock_client_cls.side_effect = [client1, client2]
     pool = mock_pool_cls.return_value
-    db_obj = mock.Mock(name='db')
+    db_obj = mock.Mock(name="db")
     pool._db = db_obj
 
     with app.app_context():
         conn = arango.connect()
 
     assert conn is db_obj
-    mock_client_cls.assert_has_calls([
-        mock.call(hosts='http://host1:8529'),
-        mock.call(hosts='http://host2:8529'),
-    ])
+    mock_client_cls.assert_has_calls(
+        [
+            mock.call(hosts="http://host1:8529"),
+            mock.call(hosts="http://host2:8529"),
+        ]
+    )
     mock_pool_cls.assert_called_once_with(
-        [client1, client2], dbname='db', username='user', password='pass'
+        [client1, client2], dbname="db", username="user", password="pass"
     )
 
 
@@ -74,7 +76,15 @@ def test_teardown_closes_connection(app):
     arango = ArangoORM(app)
     dummy_conn = mock.Mock()
     with app.app_context():
-        flask.current_app.extensions['arango'] = dummy_conn
+        flask.current_app.extensions["arango"] = dummy_conn
         arango.teardown()
-        assert flask.current_app.extensions.get('arango') is None
+        assert flask.current_app.extensions.get("arango") is None
     dummy_conn.close.assert_called_once()
+
+
+def test_missing_config_raises(app):
+    app.config.pop("ARANGODB_DATABASE")
+    arango = ArangoORM(app)
+    with app.app_context(), pytest.raises(ValueError) as exc:
+        arango.connect()
+    assert "ARANGODB_DATABASE" in str(exc.value)


### PR DESCRIPTION
## Summary
- create a module logger in `arango.py`
- log connection attempts, successes and teardowns
- validate configuration and raise `ValueError` when required values are missing
- document the logging behaviour in the README
- add tests for missing configuration exceptions

## Testing
- `pre-commit run --files flask_arango_orm/arango.py tests/test_connect.py tests/test_async_connect.py README.rst`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849cb6ed6b48333b94751d633dc7045