### PR TITLE
Add connection reuse and config error tests

### DIFF
--- a/tests/test_arango.py
+++ b/tests/test_arango.py
@@ -5,24 +5,26 @@ from flask_arango_orm.arango import ARANGODB_CLUSTER, ARANGODB_HOST
 
 
 class TestArangoORM:
-
-    @mock.patch('flask.Flask')
+    @mock.patch("flask.Flask")
     def test_init(self, mock_flask):
         app = mock_flask(__name__)
         _ = ArangoORM(app)
-        calls = [mock.call('ARANGODB_CLUSTER', ARANGODB_CLUSTER),
-                 mock.call('ARANGODB_HOST', ARANGODB_HOST)]
+        calls = [
+            mock.call("ARANGODB_CLUSTER", ARANGODB_CLUSTER),
+            mock.call("ARANGODB_HOST", ARANGODB_HOST),
+        ]
         app.config.setdefault.assert_has_calls(calls)
 
     def test_init_no_app(self):
         arango = ArangoORM()
         assert arango.app is None
 
-    @mock.patch.object(ArangoORM, 'connect')
+    @mock.patch.object(ArangoORM, "connect")
     def test_connection_attribute(self, mock_connect):
         class DummyConn:
             def __init__(self):
                 self.closed = False
+
             def close(self):
                 self.closed = True
 
@@ -30,10 +32,29 @@ class TestArangoORM:
         mock_connect.return_value = test_conn
 
         import flask
+
         app = flask.Flask(__name__)
         arango = ArangoORM(app)
         with app.test_request_context():
             db_conn = arango.connection
             assert db_conn is test_conn
-            assert app.extensions['arango'] is test_conn
+            assert app.extensions["arango"] is test_conn
         assert test_conn.closed
+
+    @mock.patch.object(ArangoORM, "connect")
+    def test_connection_repeated_use(self, mock_connect):
+        import flask
+
+        db_obj = object()
+        mock_connect.return_value = db_obj
+
+        app = flask.Flask(__name__)
+        arango = ArangoORM(app)
+
+        with app.test_request_context():
+            first = arango.connection
+            second = arango.connection
+
+            assert first is second
+            assert app.extensions["arango"] is db_obj
+        mock_connect.assert_called_once()

--- a/tests/test_async_connect.py
+++ b/tests/test_async_connect.py
@@ -91,3 +91,29 @@ async def test_missing_config_raises(app):
     with pytest.raises(ValueError) as exc:
         await arango.connect()
     assert "ARANGODB_DATABASE" in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_invalid_host_definition(app):
+    app.config["ARANGODB_HOST"] = ("http", "localhost")
+    arango = AsyncArangoORM(app)
+    ctx = app.app_context()
+    ctx.push()
+    app.do_teardown_appcontext = lambda exc=None: None
+    with pytest.raises(ValueError):
+        await arango.connect()
+
+
+@pytest.mark.asyncio
+async def test_invalid_host_pool_definition(app):
+    app.config["ARANGODB_CLUSTER"] = True
+    app.config["ARANGODB_HOST_POOL"] = [
+        ("http", "host1", 8529),
+        ("http", "host2"),
+    ]
+    arango = AsyncArangoORM(app)
+    ctx = app.app_context()
+    ctx.push()
+    app.do_teardown_appcontext = lambda exc=None: None
+    with pytest.raises(ValueError):
+        await arango.connect()

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -88,3 +88,21 @@ def test_missing_config_raises(app):
     with app.app_context(), pytest.raises(ValueError) as exc:
         arango.connect()
     assert "ARANGODB_DATABASE" in str(exc.value)
+
+
+def test_invalid_host_definition(app):
+    app.config["ARANGODB_HOST"] = ("http", "localhost")
+    arango = ArangoORM(app)
+    with app.app_context(), pytest.raises(ValueError):
+        arango.connect()
+
+
+def test_invalid_host_pool_definition(app):
+    app.config["ARANGODB_CLUSTER"] = True
+    app.config["ARANGODB_HOST_POOL"] = [
+        ("http", "host1", 8529),
+        ("http", "host2"),
+    ]
+    arango = ArangoORM(app)
+    with app.app_context(), pytest.raises(ValueError):
+        arango.connect()


### PR DESCRIPTION
## Summary
- expand ArangoORM connection tests to verify reuse
- add equivalent async tests with `pytest.mark.asyncio`
- cover invalid host definitions in sync and async connect tests

## Testing
- `pre-commit run --files tests/test_arango.py tests/test_async_arango.py tests/test_connect.py tests/test_async_connect.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849cd5503a88333b325c260071f8e3e